### PR TITLE
Improve TexConv setting descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 - Create a new folder called "io_scene_bfres".
 - Copy in all `*.py` files from the `src` folder of this repository.
 - In the Blender user preferences, enable the 'Import-Export: Nintendo BFRES format' add-on.
-- Configure the path to the TexConv.exe utility if you want to import textures.
+- If you want to import textures, you have to provide the path to the TexConv executable (the program, not the folder it resides in). You can set this path in the add-on preferences by expanding the add-on's section there.
 
 License
 =======

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -58,8 +58,8 @@ class BfresAddonPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
     tex_conv_path = bpy.props.StringProperty(
-        name='TexConv Path',
-        description='Path of the proprietary TexConv utility to convert textures with.',
+        name='TexConv Executable Path',
+        description='Path of the proprietary TexConv executable to convert textures with.',
         subtype='FILE_PATH'
     )
 


### PR DESCRIPTION
Several users did not correctly understand how to set up TexConv (and often chose just the folder, not the executable). Readme updated and label in add-on settings now improved to speak about the programs "executable".